### PR TITLE
Append to the tmp file in jlab.sh instead

### DIFF
--- a/jlab.sh
+++ b/jlab.sh
@@ -47,7 +47,7 @@ tcsh ${TCSH_ARG} -c "source ${JLAB_ROOT}/${JLAB_VERSION}/ce/jlab.csh ${JLAB_VERS
     ## Dump information messages (and everything else) to STDERR where it should not hurt anyone
     print STDERR "$_\n";
   }
-' > $TMPF
+' >> $TMPF
 
 source "$TMPF"
 rm -f "$TMPF"


### PR DESCRIPTION
- avoids issuse when bash 'noclobber' setting is enabled