### PR TITLE
Add ROOT Libraries to the PYTHONPATH variable

### DIFF
--- a/devel/ce/root.env
+++ b/devel/ce/root.env
@@ -15,4 +15,5 @@ checkSoftware.py ROOT $ROOTSYS $PROPOSEDINSTALL $ROOT_VERSION $DEFAULT_ROOT_VERS
 # To keep some compatibility with the past adding both lib and lib/root in the parh
 # setenv ROOTLIB  $ROOTSYS/lib # not sure if this one is needed
 setenv LD_LIBRARY_PATH $ROOTSYS/lib/root:$ROOTSYS/lib:${LD_LIBRARY_PATH}
+setenv PYTHONPATH $ROOTSYS/lib:${PYTHONPATH}
 set path = ($ROOTSYS/bin $path) 


### PR DESCRIPTION
Allow Python to use libraries available in $ROOTSYS/lib, needed for the execution of scripts available in $ROOTSYS/bin such as rootprint, rootrm, etc. 