### PR TITLE
Update get_coptions

### DIFF
--- a/2.1/install/get_coptions
+++ b/2.1/install/get_coptions
@@ -76,9 +76,14 @@ if($1 == "dir") exit
 
 # check the cmake version
 # Issue warning if it's not >= 3.3
+# Need to do numerical comparison instead of alphabetical
+# for minor version >=10
 cmakev:
 	set cmake_version     = `cmake --version | head -1 | awk '{print $3}' | awk -F- '{print $1}' | awk -F. '{print $1"."$2}'`
-	if( `echo "$cmake_version < 3.3" | bc `) then
+ 	set cmake_major     = `cmake --version | head -1 | awk '{print $3}' | awk -F- '{print $1}' | awk -F. '{print $1}'`
+ 	set cmake_minor     = `cmake --version | head -1 | awk '{print $3}' | awk -F- '{print $1}' | awk -F. '{print $2}'`
+ 	if( ($cmake_major < 3) || ($cmake_major == 3 && $cmake_minor < 3)) then
+#	if( `echo "$cmake_version < 3.3" | bc `) then
 		echo cmake version is $cmake_version, 3.3 or higher is needed
 	else
 		echo OK


### PR DESCRIPTION
The alphabetical comparison for the cmake version fails at 3.10; change to a numerical comparison.