### PR TITLE
Add Podd (Hall A analyzer) release 1.6.6

### DIFF
--- a/ce/jlab.csh
+++ b/ce/jlab.csh
@@ -17,7 +17,7 @@ set CE_DATE = "(Wed October 3 2018)"
 setenv PATH $JLAB_ROOT/$JLAB_VERSION/ce:$PATH
 
 # Software packages
-set packages = (banks ccdb clhep evio geant4 gemc jana mlibrary mysql qt root scons xercesc)
+set packages = (banks ccdb clhep evio geant4 gemc jana mlibrary mysql qt root scons xercesc podd)
 if ( -f ~/.jlab_software) then
 	set packages = `cat ~/.jlab_software`
 endif

--- a/ce/podd.env
+++ b/ce/podd.env
@@ -1,0 +1,20 @@
+## Podd (Hall A analyzer) environment
+
+# set the version according to user preferences
+setenv PODD_VERSION `getVersion.py PODD_VERSION $DEFAULT_PODD_VERSION $overwrite`
+
+set PROPOSEDINSTALL =  $JLAB_SOFTWARE/podd/$PODD_VERSION
+
+# set the location according to user preferences
+setenv PODD `getVersion.py PODD $PROPOSEDINSTALL $overwrite`
+# needed by Hall C software and various scripts
+setenv ANALYZER $PODD
+
+# verify installation and print log
+checkSoftware.py PODD $PODD $PROPOSEDINSTALL $PODD_VERSION $DEFAULT_PODD_VERSION $PODD/lib
+
+
+# complete setting the environment
+setenv LD_LIBRARY_PATH $PODD/lib:${LD_LIBRARY_PATH}
+
+set path = ($PODD/bin $path)

--- a/ce/versions.env
+++ b/ce/versions.env
@@ -31,6 +31,7 @@ else if ($JLAB_VERSION == "devel") then
 	set DEFAULT_ROOT_VERSION     = 6.16.00
 	set DEFAULT_SCONS_BM_VERSION = 1.8
 	set DEFAULT_XERCESC_VERSION  = 3.2.2
+	set DEFAULT_PODD_VERSION     = 1.6.6
 endif
 
 

--- a/install/get_coptions
+++ b/install/get_coptions
@@ -100,6 +100,8 @@ logFile:
 		echo "$JLAB_SOFTWARE/banks/$BANKS_VERSION/build_log"
 	else if($2 == "jana") then
 		echo "$JANA_HOME/build_log"
+	else if($2 == "podd") then
+		echo "$PODD/build_log"
 	endif
 if($1 == "logFile") exit
 
@@ -126,6 +128,8 @@ logFileS:
 		echo \$JLAB_SOFTWARE/"banks/$BANKS_VERSION/build_log"
 	else if($2 == "jana") then
 		echo \$JANA_HOME/"build_log"
+	else if($2 == "podd") then
+		echo \$PODD/"build_log"
 	endif
 if($1 == "logFileS") exit
 

--- a/install/go_all
+++ b/install/go_all
@@ -20,4 +20,4 @@
 ./go_root
 ./go_banks
 ./go_jana
-
+./go_podd

--- a/install/go_podd
+++ b/install/go_podd
@@ -1,0 +1,67 @@
+#!/bin/csh -f
+
+# Get the Podd tar file from the website:
+# https://redmine.jlab.org/projects/podd/wiki
+
+# Additional settings at the top of get_coptions
+set getCoptions = $JLAB_ROOT/$JLAB_VERSION/install/get_coptions
+
+# Options
+set name     = podd
+set release  = `$getCoptions release`
+set repo     = `$getCoptions repo`/podd
+set version  = $PODD_VERSION
+set filename =  "analyzer-1.6.6.tar.gz"
+set opt      = `$getCoptions copt`
+set blog     = `$getCoptions logFile podd`
+set blogS    = `$getCoptions logFileS podd`
+set sourceDir = $PODD/dist
+
+# Write options on screen
+$getCoptions log $name $version $filename $release $opt
+
+if($1 == "src"|| $1 == "make") goto $1
+
+# Source Build
+src:
+    # start message
+    $getCoptions installLog $name $version
+
+    # create dirs
+    $getCoptions removeAndCreate $PODD/dist/build
+
+    # unpacking inside source
+    cd $sourceDir
+    $getCoptions getAndUnpackTo $repo $filename .
+if($1 == "src") exit
+
+# make
+make:
+
+    set buildDir  = $sourceDir/build
+    cd $buildDir
+
+    # log start of compilation
+    $getCoptions logStart $blog $blogS
+
+    # the  -Wno-dev  flag is to ignore the project developers cmake warnings for policy CMP0075
+    cmake -Wno-dev -DCMAKE_INSTALL_PREFIX=$PODD -DCMAKE_INSTALL_LIBDIR=$PODD/lib $sourceDir >> $blog
+
+    make $opt    >> $blog
+    make install >> $blog
+
+    # log end of compilation, total time
+    $getCoptions logEnd  $blog
+    $getCoptions logTime $blog
+
+if($1 == "make") exit
+
+# Cleaning up
+echo " > Cleaning up..."
+cd $PODD
+# comment this if they need debugging
+rm -rf $sourceDir
+
+# Done
+echo " > Done."
+echo


### PR DESCRIPTION
Requires EVIO 5.2 (ideally JeffersonLab/evio@0e762283fd27b755bb02232206eca5f9f30b60a8, but at least the fix from JeffersonLab/evio@b98ec629e517b7424c12eed9db13ac5c142224cb) to work correctly. Podd will deadlock with EVIO 5.1, as may other software. EVIO 5.1 contains numerous known bugs and should be upgraded asap anyway.